### PR TITLE
Enable TLS Support

### DIFF
--- a/buildenv
+++ b/buildenv
@@ -14,8 +14,8 @@ export ZOPEN_MAKE="zopen_make"
 export ZOPEN_SYSTEM_PREREQ="zos25"
 
 zopen_make() {
-	cd deps; make "$@" fast_float  fpconv  hdr_histogram	hiredis  linenoise lua; cd -
-	make "$@"
+	cd deps; make "$@" BUILD_TLS=yes fast_float  fpconv  hdr_histogram	hiredis  linenoise lua; cd -
+	make "$@" BUILD_TLS=yes
 }
 
 zopen_pre_patch()


### PR DESCRIPTION
bind 127.0.0.1
tcp-backlog 511
tcp-keepalive 300
pidfile ./redis.pid
logfile ./redis.log
dir ./
dbfilename gary.rdb
loglevel notice

protected-mode yes

port 0
tls-port 6379
tls-cert-file ./redis.crt
tls-key-file ./redis.key
tls-ca-cert-file ./redis.crt

If Already port is in use issue occurs (observed when not disconnected properly), please kill in background using **redis-cli -p 6379 shutdown**
